### PR TITLE
CD-1956 assertions to checks without crashes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ subprojects {
 
     plugins.withId("org.gradle.maven-publish") {
         group = "me.campusapp.parsers"
-        version = "0.7.3"
+        version = "0.7.4"
 
         configure<JavaPluginExtension> {
             withJavadocJar()

--- a/parser-sdk/src/main/kotlin/ru/campus/parser/sdk/base/BaseParser.kt
+++ b/parser-sdk/src/main/kotlin/ru/campus/parser/sdk/base/BaseParser.kt
@@ -105,13 +105,18 @@ abstract class BaseParser(
                 val intervals: List<Schedule.Interval> = weekScheduleItems
                     .filter { it.dayCondition(date) && it.dayOfWeek == date.dayOfWeek }
                     .sortedBy { it.timeTableInterval.lessonNumber }
-                    .map { item ->
-                        Schedule.Interval(
-                            number = item.timeTableInterval.lessonNumber,
-                            start = item.timeTableInterval.startTime,
-                            end = item.timeTableInterval.endTime,
-                            lessons = listOf(item.lesson)
-                        )
+                    .mapNotNull { item ->
+                        try {
+                            Schedule.Interval(
+                                number = item.timeTableInterval.lessonNumber,
+                                start = item.timeTableInterval.startTime,
+                                end = item.timeTableInterval.endTime,
+                                lessons = listOf(item.lesson)
+                            )
+                        } catch (error: IllegalStateException) {
+                            logger.error(error)
+                            null
+                        }
                     }
                     .let(postprocessIntervals)
 

--- a/parser-sdk/src/main/kotlin/ru/campus/parser/sdk/model/Schedule.kt
+++ b/parser-sdk/src/main/kotlin/ru/campus/parser/sdk/model/Schedule.kt
@@ -89,24 +89,34 @@ fun List<Schedule.Entity>.enrichEntities(
     fullEntities: List<Entity>,
     onNotFound: (Schedule.Entity) -> Unit,
 ): List<Schedule.Entity> {
-    return map { shortEntity ->
+    return mapNotNull { shortEntity ->
         val fullEntityByCode = fullEntities.firstOrNull { it.code == shortEntity.code }
         if (fullEntityByCode != null) {
-            return@map Schedule.Entity(
-                name = fullEntityByCode.name,
-                code = shortEntity.code
-            )
+            return@mapNotNull try {
+                Schedule.Entity(
+                    name = fullEntityByCode.name,
+                    code = shortEntity.code
+                )
+            } catch (error: IllegalStateException) {
+                error.printStackTrace()
+                null
+            }
         }
 
         val fullEntityByName = fullEntities.singleOrNull { it.name == shortEntity.name }
         if (fullEntityByName != null) {
-            return@map Schedule.Entity(
-                name = shortEntity.name,
-                code = fullEntityByName.code
-            )
+            return@mapNotNull try {
+                Schedule.Entity(
+                    name = shortEntity.name,
+                    code = fullEntityByName.code
+                )
+            } catch (error: IllegalStateException) {
+                error.printStackTrace()
+                null
+            }
         }
 
         onNotFound(shortEntity)
-        return@map shortEntity
+        return@mapNotNull shortEntity
     }
 }

--- a/parser-sdk/src/main/kotlin/ru/campus/parser/sdk/utils/Asserts.kt
+++ b/parser-sdk/src/main/kotlin/ru/campus/parser/sdk/utils/Asserts.kt
@@ -14,28 +14,28 @@ private val urlValidator = UrlValidator(ALLOW_2_SLASHES)
 fun <T : String?> assertTimeValid(property: KProperty<T>) {
     val value: String = property.call() ?: return
 
-    assert(timeRegex.matches(value)) { "${property.name} [$value] have invalid format" }
+    check(timeRegex.matches(value)) { "${property.name} [$value] have invalid format" }
     val (hours: Int, minutes: Int) = value.split(":").map { it.toInt() }
-    assert(hours in 0..23) { "hours should be in 0..23" }
-    assert(minutes in 0..59) { "minutes should be in 0..59" }
+    check(hours in 0..23) { "hours should be in 0..23" }
+    check(minutes in 0..59) { "minutes should be in 0..59" }
 }
 
 fun <T : String?> assertLength(property: KProperty<T>, minLength: Int, maxLength: Int) {
     val value: String = property.call() ?: return
-    assert(value.length in minLength until maxLength) { "${property.name} [$value] should be more than $minLength and less $maxLength characters" }
+    check(value.length in minLength until maxLength) { "${property.name} [$value] should be more than $minLength and less $maxLength characters" }
 }
 
 fun <T : String?> assertUrl(property: KProperty<T>) {
     val value: String = property.call() ?: return
-    assert(urlValidator.isValid(value)) { "${property.name} [$value] invalid url" }
+    check(urlValidator.isValid(value)) { "${property.name} [$value] invalid url" }
 }
 
 fun <T : String?> assertLength(property: KProperty<T>, length: Int) {
     val value: String = property.call() ?: return
-    assert(value.length > length) { "${property.name} [$value] should be more than $length character" }
+    check(value.length > length) { "${property.name} [$value] should be more than $length character" }
 }
 
 fun <T : Int?> assertMin(property: KProperty<T>, minValue: Int) {
     val value: Int = property.call() ?: return
-    assert(value > minValue) { "${property.name} [$value] should be more than $minValue" }
+    check(value > minValue) { "${property.name} [$value] should be more than $minValue" }
 }

--- a/parser-sdk/src/main/kotlin/ru/campus/parser/sdk/utils/IntervalsPostprocessing.kt
+++ b/parser-sdk/src/main/kotlin/ru/campus/parser/sdk/utils/IntervalsPostprocessing.kt
@@ -7,14 +7,19 @@ package ru.campus.parser.sdk.utils
 import ru.campus.parser.sdk.model.Schedule
 
 fun List<Schedule.Interval>.groupLessonsInIntervals(): List<Schedule.Interval> {
-    return groupBy { Triple(it.number, it.start, it.end) }.map { (group, intervals) ->
+    return groupBy { Triple(it.number, it.start, it.end) }.mapNotNull { (group, intervals) ->
         val lessons: List<Schedule.Lesson> = intervals.flatMap { it.lessons }.distinct()
 
-        Schedule.Interval(
-            number = group.first,
-            start = group.second,
-            end = group.third,
-            lessons = lessons
-        )
+        try {
+            Schedule.Interval(
+                number = group.first,
+                start = group.second,
+                end = group.third,
+                lessons = lessons
+            )
+        } catch (error: IllegalStateException) {
+            error.printStackTrace()
+            null
+        }
     }
 }

--- a/samples/spbstu-parser/src/main/kotlin/ru/campus/parsers/spbstu/group/SPBSTUGroupEntitiesCollector.kt
+++ b/samples/spbstu-parser/src/main/kotlin/ru/campus/parsers/spbstu/group/SPBSTUGroupEntitiesCollector.kt
@@ -38,25 +38,30 @@ class SPBSTUGroupEntitiesCollector(
             val facultyName: String = facultyElement.ownText()
             val facultyBody: String = httpClient.get(facultyUrl).body()
             val json: SpbstuFaculty = Json.decodeFromString(facultyBody)
-            json.groups.map { groupObject ->
+            json.groups.mapNotNull { groupObject ->
                 val groupName: String = groupObject.groupName
                 val code: String = groupObject.code.toString()
                 val course: Int = groupObject.course
                 val educationForm: String = groupObject.educationForm
                 val degree: Int = groupObject.degree
                 val url = "$baseUrl/faculty/$facultyCode/groups/$code"
-                Entity(
-                    name = groupName,
-                    code = code,
-                    scheduleUrl = url,
-                    type = Entity.Type.Group,
-                    extra = Entity.Extra(
-                        faculty = facultyName,
-                        course = course,
-                        degree = getDegree(degree),
-                        educationForm = getEducationForm(educationForm)
+                try {
+                    Entity(
+                        name = groupName,
+                        code = code,
+                        scheduleUrl = url,
+                        type = Entity.Type.Group,
+                        extra = Entity.Extra(
+                            faculty = facultyName,
+                            course = course,
+                            degree = getDegree(degree),
+                            educationForm = getEducationForm(educationForm)
+                        )
                     )
-                )
+                } catch (error: IllegalStateException) {
+                    error.printStackTrace()
+                    null
+                }
             }
         }
     }


### PR DESCRIPTION
Протестировал на старой версии парсера irgups, в котором куча этих ассертерроров, всё отработало нормально, ошибок 138 штук выдало, парсер не останавливался.
После релиза и поднятия версии парсера в jvm, могут в теории упасть некоторые парсеры из за использования конструкторов с кривыми данными прям в коде парсера, надо будет бегать чинить.